### PR TITLE
Update for new SDK Call object model

### DIFF
--- a/ObjCVoiceQuickstart/Info.plist
+++ b/ObjCVoiceQuickstart/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>$(EXECUTABLE_NAME) would like to access your microphone</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -22,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$(EXECUTABLE_NAME) would like to access your microphone</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -162,11 +162,12 @@ typedef void (^RingtonePlaybackCallback)(void);
     typeof(self) __weak weakSelf = self;
 
     UIAlertAction *reject = [UIAlertAction actionWithTitle:@"Reject" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        typeof(self) __strong strongSelf = weakSelf;
         [self stopIncomingRingtone:^{
             [callInvite reject];
+            strongSelf.callInvite = nil;
         }];
 
-        typeof(self) __strong strongSelf = weakSelf;
         strongSelf.incomingAlertController = nil;
         [strongSelf toggleUIState:YES];
     }];
@@ -178,6 +179,7 @@ typedef void (^RingtonePlaybackCallback)(void);
         [self stopIncomingRingtone:nil];
 
         typeof(self) __strong strongSelf = weakSelf;
+        strongSelf.callInvite = nil;
         strongSelf.incomingAlertController = nil;
         [strongSelf toggleUIState:YES];
     }];
@@ -187,6 +189,7 @@ typedef void (^RingtonePlaybackCallback)(void);
         typeof(self) __strong strongSelf = weakSelf;
         [self stopIncomingRingtone:^{
             [callInvite acceptWithDelegate:strongSelf];
+            strongSelf.callInvite = nil;
         }];
 
         strongSelf.incomingAlertController = nil;

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -141,6 +141,10 @@ typedef void (^RingtonePlaybackCallback)(void);
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteReceived:");
     
+    if (self.callInvite && self.callInvite.state == TVOCallInviteStatePending) {
+        NSLog(@"Already a pending call invite. Ignoring incoming call invite from %@", callInvite.from);
+        return;
+    }
     if (self.call && self.call.state == TVOCallStateConnected) {
         NSLog(@"Already an active call. Ignoring incoming call invite from %@", callInvite.from);
         return;

--- a/Podfile
+++ b/Podfile
@@ -4,5 +4,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'ObjCVoiceQuickstart' do
   use_frameworks!
 
-  pod 'TwilioVoiceClient', '=2.0.0-beta5'
+  pod 'TwilioVoiceClient', '=2.0.0-beta6'
 end


### PR DESCRIPTION
The latest Voice SDK has consolidated the `TVOIncomingCall` & `TVOOutgoingCall` objects into an unified `TVOCall` object. A new `TVOCallInvite` object is also introduced to abstract the incoming attributes from the original `TVOIncomingCall` object.

Also added some sample code to demonstrate how to use the `TVOCall.disconnect` method to hang up the call properly.