### PR TITLE
Bump to 2.0.0-beta13

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,13 +4,15 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '=2.0.0-beta12'
+  pod 'TwilioVoice', '2.0.0-beta13'
 
   target 'ObjCVoiceQuickstart' do
+    platform :ios, '8.1'
     project 'ObjCVoiceQuickstart.xcproject'
   end
 
   target 'ObjCVoiceCallKitQuickstart' do
+    platform :ios, '10.0'
     project 'ObjCVoiceCallKitQuickstart.xcproject'
   end
 end


### PR DESCRIPTION
Consume 2.0.0-beta13, which does not require any code changes. I specified the platform at the target level to suppress CocoaPods warnings.

> [!] Automatically assigning platform ios with version 8.1 on target ObjCVoiceQuickstart because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.
> 
> [!] Automatically assigning platform ios with version 10.0 on target ObjCVoiceCallKitQuickstart because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.
> 