### PR TITLE
Remove CocoaPods from the Xcode projects.

### DIFF
--- a/ObjCVoiceCallKitQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVoiceCallKitQuickstart.xcodeproj/project.pbxproj
@@ -14,12 +14,9 @@
 		2459FDD61D83664300917CA9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2459FDD51D83664300917CA9 /* Assets.xcassets */; };
 		2459FDD91D83664300917CA9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2459FDD71D83664300917CA9 /* LaunchScreen.storyboard */; };
 		24BA34291D87431000B0B4F7 /* TwilioLogo.png in Resources */ = {isa = PBXBuildFile; fileRef = 24BA34281D87431000B0B4F7 /* TwilioLogo.png */; };
-		6253F3DB934562CEBE07AA86 /* libPods-TwilioVoice-ObjCVoiceCallKitQuickstart.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 16C86AE60A7B1FA96D46A90C /* libPods-TwilioVoice-ObjCVoiceCallKitQuickstart.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		16C86AE60A7B1FA96D46A90C /* libPods-TwilioVoice-ObjCVoiceCallKitQuickstart.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TwilioVoice-ObjCVoiceCallKitQuickstart.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		200F5444BBE3FE4EA1F58FDA /* Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.debug.xcconfig"; sourceTree = "<group>"; };
 		2459FDC61D83664300917CA9 /* ObjCVoiceCallKitQuickstart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCVoiceCallKitQuickstart.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2459FDCA1D83664300917CA9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2459FDCC1D83664300917CA9 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -32,12 +29,6 @@
 		2459FDDA1D83664300917CA9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		24BA34241D87269500B0B4F7 /* ObjCVoiceCallKitQuickstart.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ObjCVoiceCallKitQuickstart.entitlements; sourceTree = "<group>"; };
 		24BA34281D87431000B0B4F7 /* TwilioLogo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TwilioLogo.png; sourceTree = "<group>"; };
-		45F140B0EFB703C4397736A0 /* Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.release.xcconfig"; path = "Pods/Target Support Files/Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart/Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.release.xcconfig"; sourceTree = "<group>"; };
-		46CB7828428C0DCCBD8C1237 /* Pods-ObjCVoiceCallKitQuickstart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjCVoiceCallKitQuickstart.release.xcconfig"; path = "Pods/Target Support Files/Pods-ObjCVoiceCallKitQuickstart/Pods-ObjCVoiceCallKitQuickstart.release.xcconfig"; sourceTree = "<group>"; };
-		58793B929D0C0253BAEAAE08 /* Pods-ObjCVoiceCallKitQuickstart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjCVoiceCallKitQuickstart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ObjCVoiceCallKitQuickstart/Pods-ObjCVoiceCallKitQuickstart.debug.xcconfig"; sourceTree = "<group>"; };
-		6F214C19D17B19FA31DC9C07 /* Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart/Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.debug.xcconfig"; sourceTree = "<group>"; };
-		BB7687FC0AD91BB81CA3D1B8 /* libPods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F4ADD836D068FB8CD4901F77 /* Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.release.xcconfig"; path = "Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,7 +36,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6253F3DB934562CEBE07AA86 /* libPods-TwilioVoice-ObjCVoiceCallKitQuickstart.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,7 +47,6 @@
 			children = (
 				2459FDC81D83664300917CA9 /* ObjCVoiceCallKitQuickstart */,
 				2459FDC71D83664300917CA9 /* Products */,
-				BA1056EA4B6DA67F30E5B4CF /* Pods */,
 				5FF12A4D246637936B670360 /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -99,23 +88,8 @@
 		5FF12A4D246637936B670360 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				BB7687FC0AD91BB81CA3D1B8 /* libPods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.a */,
-				16C86AE60A7B1FA96D46A90C /* libPods-TwilioVoice-ObjCVoiceCallKitQuickstart.a */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		BA1056EA4B6DA67F30E5B4CF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				58793B929D0C0253BAEAAE08 /* Pods-ObjCVoiceCallKitQuickstart.debug.xcconfig */,
-				46CB7828428C0DCCBD8C1237 /* Pods-ObjCVoiceCallKitQuickstart.release.xcconfig */,
-				6F214C19D17B19FA31DC9C07 /* Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.debug.xcconfig */,
-				45F140B0EFB703C4397736A0 /* Pods-TwilioVoiceClient-ObjCVoiceCallKitQuickstart.release.xcconfig */,
-				200F5444BBE3FE4EA1F58FDA /* Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.debug.xcconfig */,
-				F4ADD836D068FB8CD4901F77 /* Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.release.xcconfig */,
-			);
-			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -125,12 +99,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2459FDDD1D83664300917CA9 /* Build configuration list for PBXNativeTarget "ObjCVoiceCallKitQuickstart" */;
 			buildPhases = (
-				9E5B1467F0544672186A952E /* [CP] Check Pods Manifest.lock */,
 				2459FDC21D83664300917CA9 /* Sources */,
 				2459FDC31D83664300917CA9 /* Frameworks */,
 				2459FDC41D83664300917CA9 /* Resources */,
-				5A2D8C18C776001B0C12696A /* [CP] Embed Pods Frameworks */,
-				B4B8DBBFCF12A6B29385234F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -195,54 +166,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		5A2D8C18C776001B0C12696A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9E5B1467F0544672186A952E /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		B4B8DBBFCF12A6B29385234F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart/Pods-TwilioVoice-ObjCVoiceCallKitQuickstart-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2459FDC21D83664300917CA9 /* Sources */ = {
@@ -369,7 +292,6 @@
 		};
 		2459FDDE1D83664300917CA9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 200F5444BBE3FE4EA1F58FDA /* Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ObjCVoiceCallKitQuickstart/ObjCVoiceCallKitQuickstart.entitlements;
@@ -383,7 +305,6 @@
 		};
 		2459FDDF1D83664300917CA9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F4ADD836D068FB8CD4901F77 /* Pods-TwilioVoice-ObjCVoiceCallKitQuickstart.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ObjCVoiceCallKitQuickstart/ObjCVoiceCallKitQuickstart.entitlements;

--- a/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
@@ -17,11 +17,9 @@
 		8F1A927A1DF7E96700609990 /* disconnect.wav in Resources */ = {isa = PBXBuildFile; fileRef = 8F1A92771DF7E96700609990 /* disconnect.wav */; };
 		8F1A927B1DF7E96700609990 /* incoming.wav in Resources */ = {isa = PBXBuildFile; fileRef = 8F1A92781DF7E96700609990 /* incoming.wav */; };
 		8F1A927C1DF7E96700609990 /* outgoing.wav in Resources */ = {isa = PBXBuildFile; fileRef = 8F1A92791DF7E96700609990 /* outgoing.wav */; };
-		9C4288FC5CA60F4922C9B007 /* libPods-TwilioVoice-ObjCVoiceQuickstart.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C283C595EC185ADF5AC4C7D /* libPods-TwilioVoice-ObjCVoiceQuickstart.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0C283C595EC185ADF5AC4C7D /* libPods-TwilioVoice-ObjCVoiceQuickstart.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TwilioVoice-ObjCVoiceQuickstart.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2459FDC61D83664300917CA9 /* ObjCVoiceQuickstart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCVoiceQuickstart.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2459FDCA1D83664300917CA9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2459FDCC1D83664300917CA9 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -34,9 +32,6 @@
 		2459FDDA1D83664300917CA9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		24BA34241D87269500B0B4F7 /* ObjCVoiceQuickstart.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ObjCVoiceQuickstart.entitlements; sourceTree = "<group>"; };
 		24BA34281D87431000B0B4F7 /* TwilioLogo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TwilioLogo.png; sourceTree = "<group>"; };
-		56C6727DBB7CD8C7950D2CD5 /* libPods-TwilioVoiceClient-ObjCVoiceQuickstart.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TwilioVoiceClient-ObjCVoiceQuickstart.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		75B553E731EF9387F808F262 /* Pods-TwilioVoice-ObjCVoiceQuickstart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwilioVoice-ObjCVoiceQuickstart.release.xcconfig"; path = "Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceQuickstart/Pods-TwilioVoice-ObjCVoiceQuickstart.release.xcconfig"; sourceTree = "<group>"; };
-		860153D3C02C8472515DB411 /* Pods-TwilioVoice-ObjCVoiceQuickstart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TwilioVoice-ObjCVoiceQuickstart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceQuickstart/Pods-TwilioVoice-ObjCVoiceQuickstart.debug.xcconfig"; sourceTree = "<group>"; };
 		8F1A92771DF7E96700609990 /* disconnect.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = disconnect.wav; sourceTree = "<group>"; };
 		8F1A92781DF7E96700609990 /* incoming.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = incoming.wav; sourceTree = "<group>"; };
 		8F1A92791DF7E96700609990 /* outgoing.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = outgoing.wav; sourceTree = "<group>"; };
@@ -47,7 +42,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9C4288FC5CA60F4922C9B007 /* libPods-TwilioVoice-ObjCVoiceQuickstart.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,7 +54,6 @@
 				2459FDC81D83664300917CA9 /* ObjCVoiceQuickstart */,
 				8F1A92761DF7E96700609990 /* Ringtones */,
 				2459FDC71D83664300917CA9 /* Products */,
-				BA1056EA4B6DA67F30E5B4CF /* Pods */,
 				5FF12A4D246637936B670360 /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -102,8 +95,6 @@
 		5FF12A4D246637936B670360 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				56C6727DBB7CD8C7950D2CD5 /* libPods-TwilioVoiceClient-ObjCVoiceQuickstart.a */,
-				0C283C595EC185ADF5AC4C7D /* libPods-TwilioVoice-ObjCVoiceQuickstart.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -118,15 +109,6 @@
 			path = Ringtones;
 			sourceTree = "<group>";
 		};
-		BA1056EA4B6DA67F30E5B4CF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				860153D3C02C8472515DB411 /* Pods-TwilioVoice-ObjCVoiceQuickstart.debug.xcconfig */,
-				75B553E731EF9387F808F262 /* Pods-TwilioVoice-ObjCVoiceQuickstart.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -134,12 +116,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2459FDDD1D83664300917CA9 /* Build configuration list for PBXNativeTarget "ObjCVoiceQuickstart" */;
 			buildPhases = (
-				9E5B1467F0544672186A952E /* [CP] Check Pods Manifest.lock */,
 				2459FDC21D83664300917CA9 /* Sources */,
 				2459FDC31D83664300917CA9 /* Frameworks */,
 				2459FDC41D83664300917CA9 /* Resources */,
-				5A2D8C18C776001B0C12696A /* [CP] Embed Pods Frameworks */,
-				B4B8DBBFCF12A6B29385234F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -207,54 +186,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		5A2D8C18C776001B0C12696A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceQuickstart/Pods-TwilioVoice-ObjCVoiceQuickstart-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9E5B1467F0544672186A952E /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		B4B8DBBFCF12A6B29385234F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TwilioVoice-ObjCVoiceQuickstart/Pods-TwilioVoice-ObjCVoiceQuickstart-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2459FDC21D83664300917CA9 /* Sources */ = {
@@ -381,7 +312,6 @@
 		};
 		2459FDDE1D83664300917CA9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 860153D3C02C8472515DB411 /* Pods-TwilioVoice-ObjCVoiceQuickstart.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
@@ -394,7 +324,6 @@
 		};
 		2459FDDF1D83664300917CA9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75B553E731EF9387F808F262 /* Pods-TwilioVoice-ObjCVoiceQuickstart.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;


### PR DESCRIPTION
As much as I love CocoaPods, it shouldn't be required to use our QuickStarts. I removed the partial CocoaPods integration that exists in the examples to make manual integration easier. For CocoaPods users, a `pod install` will still perform a full integration including the modifications to the projects.