### PR TITLE
Updates for Voice 2.0.0-beta17 release

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -148,6 +148,14 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
 
 #pragma mark - TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
+    if (callInvite.state == TVOCallInviteStatePending) {
+        [self handleCallInviteReceived:callInvite];
+    } else if (callInvite.state == TVOCallInviteStateCanceled) {
+        [self handleCallInviteCanceled:callInvite];
+    }
+}
+
+- (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteReceived:");
     
     if (self.callInvite && self.callInvite == TVOCallInviteStatePending) {
@@ -165,7 +173,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     [self reportIncomingCallFrom:@"Voice Bot" withUUID:callInvite.uuid];
 }
 
-- (void)callInviteCanceled:(TVOCallInvite *)callInvite {
+- (void)handleCallInviteCanceled:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteCanceled:");
 
     [self performEndCallActionWithUUID:callInvite.uuid];

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -139,6 +139,14 @@ typedef void (^RingtonePlaybackCallback)(void);
 
 #pragma mark - TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
+    if (callInvite.state == TVOCallInviteStatePending) {
+        [self handleCallInviteReceived:callInvite];
+    } else if (callInvite.state == TVOCallInviteStateCanceled) {
+        [self handleCallInviteCanceled:callInvite];
+    }
+}
+
+- (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteReceived:");
     
     if (self.callInvite && self.callInvite.state == TVOCallInviteStatePending) {
@@ -207,7 +215,7 @@ typedef void (^RingtonePlaybackCallback)(void);
     }
 }
 
-- (void)callInviteCanceled:(TVOCallInvite *)callInvite {
+- (void)handleCallInviteCanceled:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteCanceled:");
     
     if (![callInvite.callSid isEqualToString:self.callInvite.callSid]) {

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '2.0.0-beta16'
+  pod 'TwilioVoice', '2.0.0-beta17'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '8.1'


### PR DESCRIPTION
- Podspec version bumped
- The `callInviteReceived:` method is now called for both `TVOCallInviteStatePending` and `TVOCallInviteStateCanceled` states and the original `callInviteCanceled:` method is removed from the `TVONotificationDelegate` protocol