### PR TITLE
Voice 2.0.0 beta21

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -428,14 +428,8 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     
     self.call = [TwilioVoice call:[self fetchAccessToken]
                            params:@{}
+                             uuid:uuid
                          delegate:self];
-    
-    if (!self.call) {
-        completionHandler(NO);
-    } else {
-        self.call.uuid = uuid;
-    }
-    
     self.callKitCompletionCallback = completionHandler;
 }
 
@@ -443,14 +437,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
                             completion:(void(^)(BOOL success))completionHandler {
 
     self.call = [self.callInvite acceptWithDelegate:self];
-    if (!self.call) {
-        completionHandler(NO);
-    } else {
-        self.call.uuid = uuid;
-    }
-    
     self.callInvite = nil;
-    
     self.callKitCompletionCallback = completionHandler;
 }
 

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -327,6 +327,8 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     //      `provider:performAnswerCallAction:` per the WWDC examples.
     // [[TwilioVoice sharedInstance] configureAudioSession];
 
+    NSAssert([self.callInvite.uuid isEqual:action.callUUID], @"We only support one Invite at a time.");
+    
     [self performAnswerVoiceCallWithUUID:action.callUUID completion:^(BOOL success) {
         if (success) {
             [action fulfill];
@@ -351,6 +353,15 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     [action fulfill];
 }
 
+- (void)provider:(CXProvider *)provider performSetHeldCallAction:(CXSetHeldCallAction *)action {
+    if (self.call && self.call.state == TVOCallStateConnected) {
+        [self.call setOnHold:action.isOnHold];
+        [action fulfill];
+    } else {
+        [action fail];
+    }
+}
+
 #pragma mark - CallKit Actions
 - (void)performStartCallActionWithUUID:(NSUUID *)uuid handle:(NSString *)handle {
     if (uuid == nil || handle == nil) {
@@ -370,7 +381,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
             CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
             callUpdate.remoteHandle = callHandle;
             callUpdate.supportsDTMF = YES;
-            callUpdate.supportsHolding = NO;
+            callUpdate.supportsHolding = YES;
             callUpdate.supportsGrouping = NO;
             callUpdate.supportsUngrouping = NO;
             callUpdate.hasVideo = NO;
@@ -386,7 +397,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.remoteHandle = callHandle;
     callUpdate.supportsDTMF = YES;
-    callUpdate.supportsHolding = NO;
+    callUpdate.supportsHolding = YES;
     callUpdate.supportsGrouping = NO;
     callUpdate.supportsUngrouping = NO;
     callUpdate.hasVideo = NO;

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -71,11 +71,6 @@ typedef void (^RingtonePlaybackCallback)(void);
             strongSelf.call = [TwilioVoice call:[strongSelf fetchAccessToken]
                                          params:@{}
                                        delegate:strongSelf];
-            
-            if (!strongSelf.call) {
-                NSLog(@"Failed to start outgoing call");
-                return;
-            }
         }];
         
         [self toggleUIState:NO];

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '2.0.0-beta20'
+  pod 'TwilioVoice', '2.0.0-beta21'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '8.1'


### PR DESCRIPTION
- Update Podfile version
- Return value of `TwilioVoice.call()` and `TVOCallInvite.accept()` are now `nonnull` in beta21.
- In the CallKit sample, use `TwilioVoice.call:params:uuid:delegate:` to provide proper UUID from the action. Also implemented the `provider:performSetHeldCallAction:` method to demo the newly added set-hold function of `TVOCall`.