### PR TITLE
Updates for Voice 2.0.0-beta22 release

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -275,6 +275,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
 #pragma mark - CXProviderDelegate
 - (void)providerDidReset:(CXProvider *)provider {
     NSLog(@"providerDidReset:");
+    TwilioVoice.audioEnabled = YES;
 }
 
 - (void)providerDidBegin:(CXProvider *)provider {
@@ -283,14 +284,12 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
 
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession {
     NSLog(@"provider:didActivateAudioSession:");
-
-    [TwilioVoice startAudio];
+    TwilioVoice.audioEnabled = YES;
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession {
     NSLog(@"provider:didDeactivateAudioSession:");
-    
-    [TwilioVoice stopAudio];
+    TwilioVoice.audioEnabled = NO;
 }
 
 - (void)provider:(CXProvider *)provider timedOutPerformingAction:(CXAction *)action {
@@ -304,6 +303,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     [self startSpin];
 
     [TwilioVoice configureAudioSession];
+    TwilioVoice.audioEnabled = NO;
     
     [self.callKitProvider reportOutgoingCallWithUUID:action.callUUID startedConnectingAtDate:[NSDate date]];
     
@@ -408,6 +408,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
 
             // RCP: Workaround per https://forums.developer.apple.com/message/169511
             [TwilioVoice configureAudioSession];
+            TwilioVoice.audioEnabled = NO;
         }
         else {
             NSLog(@"Failed to report incoming call successfully: %@.", [error localizedDescription]);

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '2.0.0-beta21'
+  pod 'TwilioVoice', '2.0.0-beta22'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '8.1'


### PR DESCRIPTION
- Bump `Podfile` version.
- API updates
  - `TwilioVoice.startAudio()` & `TwilioVoice.stopAudio()` are replaced by the new property `TwilioVoice.audioEnabled`.