### PR TITLE
Mention .php extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Follow the instructions in the server's README to get the application server up 
 
 ### <a name="bullet4"></a>4. Create a TwiML application
 Next, we need to create a TwiML application. A TwiML application identifies a public URL for retrieving [TwiML call control instructions](https://www.twilio.com/docs/api/twiml). When your iOS app makes a call to the Twilio cloud, Twilio will make a webhook request to this URL, your application server will respond with generated TwiML, and Twilio will execute the instructions you’ve provided.
-To create a TwiML application, go to the [TwiML app page](https://www.twilio.com/console/voice/dev-tools/twiml-apps). Create a new TwiML application, and use the public URL of your application server’s `/makeCall` endpoint as the Voice Request URL.
+To create a TwiML application, go to the [TwiML app page](https://www.twilio.com/console/voice/dev-tools/twiml-apps). Create a new TwiML application, and use the public URL of your application server’s `/makeCall` endpoint as the Voice Request URL (If your app server is written in PHP, then you need `.php` extension at the end).
 
 <kbd><img src="Images/create-twiml-app.png"/></kbd>
 
@@ -69,7 +69,7 @@ Let's put the remaining `APP_SID` configuration info into `server.py`
 
 Once you’ve done that, restart the server so it uses the new configuration info. Now it's time to test.
 
-Open up a browser and visit the URL for your application server's **Access Token endpoint**: `https://{YOUR_SERVER_URL}/accessToken`. If everything is configured correctly, you should see a long string of letters and numbers, which is a Twilio Access Token. Your iOS app will use a token like this to connect to Twilio.
+Open up a browser and visit the URL for your application server's **Access Token endpoint**: `https://{YOUR_SERVER_URL}/accessToken` (If your app server is written in PHP, then you need `.php` extension at the end). If everything is configured correctly, you should see a long string of letters and numbers, which is a Twilio Access Token. Your iOS app will use a token like this to connect to Twilio.
 
 ### <a name="bullet6"></a>6. Run the app
 Now let’s go back to the `ObjCVoiceQuickstart.xcworkspace`. Update the placeholder of `kYourServerBaseURLString` with your ngrok public URL
@@ -147,7 +147,7 @@ In Xcode 9+, add a "**UIBackgroundModes**" dictionary with "**audio**" and "**vo
 ```
 
 ### <a name="bullet10"></a>10. Receive an incoming call
-You are now ready to receive incoming calls. Rebuild your app and hit your application server's **/placeCall** endpoint: `https://{YOUR_SERVER_URL}/placeCall`. This will trigger a Twilio REST API request that will make an inbound call to your mobile app. Once your app accepts the call, you should hear a congratulatory message.
+You are now ready to receive incoming calls. Rebuild your app and hit your application server's **/placeCall** endpoint: `https://{YOUR_SERVER_URL}/placeCall` (If your app server is written in PHP, then you need `.php` extension at the end). This will trigger a Twilio REST API request that will make an inbound call to your mobile app. Once your app accepts the call, you should hear a congratulatory message.
 
 <kbd><img height="667px" src="Images/incoming-call.png"/></kbd>
 


### PR DESCRIPTION
In case the user is using the [PHP Server Quickstart](https://github.com/twilio/voice-quickstart-server-php), mention adding `.php` extension for endpoints in README.