### PR TITLE
New PushKit delegate method for iOS 11

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -169,12 +169,33 @@ static NSString *const kTwimlParamTo = @"to";
     }
 }
 
+/**
+ * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
+ * your application is targeting iOS 11. This delegate method wil soon be deprecated by Apple.
+ */
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
     if ([type isEqualToString:PKPushTypeVoIP]) {
         [TwilioVoice handleNotification:payload.dictionaryPayload
                                delegate:self];
     }
+}
+
+/**
+ * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+ * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+ */
+- (void)pushRegistry:(PKPushRegistry *)registry
+didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
+             forType:(PKPushType)type
+withCompletionHandler:(void (^)(void))completion {
+    NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:");
+    if ([type isEqualToString:PKPushTypeVoIP]) {
+        [TwilioVoice handleNotification:payload.dictionaryPayload
+                               delegate:self];
+    }
+
+    completion();
 }
 
 #pragma mark - TVONotificationDelegate

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -182,7 +182,6 @@ static NSString *const kTwimlParamTo = @"to";
 }
 
 /**
- * This is delegate method is available on iOS 11 and above. Call the completion handler once the
  * This delegate method is available on iOS 11 and above. Call the completion handler once the
  * notification payload is passed to the `TwilioVoice.handleNotification()` method.
  */

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -171,7 +171,7 @@ static NSString *const kTwimlParamTo = @"to";
 
 /**
  * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
- * your application is targeting iOS 11. This delegate method wil soon be deprecated by Apple.
+ * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
@@ -182,7 +182,7 @@ static NSString *const kTwimlParamTo = @"to";
 }
 
 /**
- * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+ * This is delegate method is available on iOS 11 and above. Call the completion handler once the
  * notification payload is passed to the `TwilioVoice.handleNotification()` method.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -183,6 +183,7 @@ static NSString *const kTwimlParamTo = @"to";
 
 /**
  * This is delegate method is available on iOS 11 and above. Call the completion handler once the
+ * This delegate method is available on iOS 11 and above. Call the completion handler once the
  * notification payload is passed to the `TwilioVoice.handleNotification()` method.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -155,7 +155,7 @@ typedef void (^RingtonePlaybackCallback)(void);
 
 /**
  * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
- * your application is targeting iOS 11. This delegate method wil soon be deprecated by Apple.
+ * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
@@ -166,7 +166,7 @@ typedef void (^RingtonePlaybackCallback)(void);
 }
 
 /**
- * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+ * This is delegate method is available on iOS 11 and above. Call the completion handler once the
  * notification payload is passed to the `TwilioVoice.handleNotification()` method.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -166,7 +166,7 @@ typedef void (^RingtonePlaybackCallback)(void);
 }
 
 /**
- * This is delegate method is available on iOS 11 and above. Call the completion handler once the
+ * This delegate method is available on iOS 11 and above. Call the completion handler once the
  * notification payload is passed to the `TwilioVoice.handleNotification()` method.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -153,12 +153,33 @@ typedef void (^RingtonePlaybackCallback)(void);
     }
 }
 
+/**
+ * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
+ * your application is targeting iOS 11. This delegate method wil soon be deprecated by Apple.
+ */
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
     if ([type isEqualToString:PKPushTypeVoIP]) {
         [TwilioVoice handleNotification:payload.dictionaryPayload
                                delegate:self];
     }
+}
+
+/**
+ * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+ * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+ */
+- (void)pushRegistry:(PKPushRegistry *)registry
+didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
+             forType:(PKPushType)type
+withCompletionHandler:(void (^)(void))completion {
+    NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:");
+    if ([type isEqualToString:PKPushTypeVoIP]) {
+        [TwilioVoice handleNotification:payload.dictionaryPayload
+                               delegate:self];
+    }
+    
+    completion();
 }
 
 #pragma mark - TVONotificationDelegate


### PR DESCRIPTION
The `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` is available on iOS 11 and above. The original `pushRegistry:didReceiveIncomingPushWithPayload:forType:` [will soon be deprecated by Apple](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/1614492-pushregistry?language=objc).

The `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method will be called if both the methods exist.

Note: calling the `TwilioVoice.handleNotification()` method is guaranteed to get at least one of the `TVONotificationDelegate` callback immediately, so it is safe to call the completion handler right after calling `TwilioVoice.handleNotification()`.