### PR TITLE
Update for Voice 3.0.0-preview1

### DIFF
--- a/ObjCVoiceCallKitQuickstart/AppDelegate.m
+++ b/ObjCVoiceCallKitQuickstart/AppDelegate.m
@@ -15,7 +15,7 @@
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    NSLog(@"Twilio Voice Version: %@", [TwilioVoice version]);
+    NSLog(@"Twilio Voice Version: %@", [TwilioVoice sdkVersion]);
     return YES;
 }
 

--- a/ObjCVoiceCallKitQuickstart/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ObjCVoiceCallKitQuickstart/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -139,6 +139,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-83.5@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -45,8 +45,6 @@ static NSString *const kTwimlParamTo = @"to";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
-    [TwilioVoice setLogLevel:TVOLogLevelAll];
 
     self.voipRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
     self.voipRegistry.delegate = self;

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -25,6 +25,7 @@ static NSString *const kTwimlParamTo = @"to";
 @property (nonatomic, strong) TVOCallInvite *callInvite;
 @property (nonatomic, strong) TVOCall *call;
 @property (nonatomic, strong) void(^callKitCompletionCallback)(BOOL);
+@property (nonatomic, strong) TVODefaultAudioDevice *audioDevice;
 
 @property (nonatomic, strong) CXProvider *callKitProvider;
 @property (nonatomic, strong) CXCallController *callKitCallController;
@@ -45,7 +46,7 @@ static NSString *const kTwimlParamTo = @"to";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    [TwilioVoice setLogLevel:TVOLogLevelVerbose];
+    [TwilioVoice setLogLevel:TVOLogLevelAll];
 
     self.voipRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
     self.voipRegistry.delegate = self;
@@ -55,6 +56,14 @@ static NSString *const kTwimlParamTo = @"to";
     self.outgoingValue.delegate = self;
 
     [self configureCallKit];
+    
+    /*
+     * The important thing to remember when providing a TVOAudioDevice is that the device must be set
+     * before performing any other actions with the SDK (such as connecting a Call, or accepting an incoming Call).
+     * In this case we've already initialized our own `TVODefaultAudioDevice` instance which we will now set.
+     */
+    self.audioDevice = [TVODefaultAudioDevice audioDevice];
+    TwilioVoice.audioDevice = self.audioDevice;
 }
 
 - (void)configureCallKit {
@@ -195,7 +204,9 @@ withCompletionHandler:(void (^)(void))completion {
                                delegate:self];
     }
 
-    completion();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion();
+    });
 }
 
 #pragma mark - TVONotificationDelegate
@@ -249,6 +260,7 @@ withCompletionHandler:(void (^)(void))completion {
     
     [self toggleUIState:YES showCallControl:YES];
     [self stopSpin];
+    [self toggleAudioRoute:YES];
 }
 
 - (void)call:(TVOCall *)call didFailToConnectWithError:(NSError *)error {
@@ -331,7 +343,7 @@ withCompletionHandler:(void (^)(void))completion {
 #pragma mark - CXProviderDelegate
 - (void)providerDidReset:(CXProvider *)provider {
     NSLog(@"providerDidReset:");
-    TwilioVoice.audioEnabled = YES;
+    self.audioDevice.enabled = YES;
 }
 
 - (void)providerDidBegin:(CXProvider *)provider {
@@ -340,12 +352,11 @@ withCompletionHandler:(void (^)(void))completion {
 
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession {
     NSLog(@"provider:didActivateAudioSession:");
-    TwilioVoice.audioEnabled = YES;
+    self.audioDevice.enabled = YES;
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession {
     NSLog(@"provider:didDeactivateAudioSession:");
-    TwilioVoice.audioEnabled = NO;
 }
 
 - (void)provider:(CXProvider *)provider timedOutPerformingAction:(CXAction *)action {
@@ -358,9 +369,8 @@ withCompletionHandler:(void (^)(void))completion {
     [self toggleUIState:NO showCallControl:NO];
     [self startSpin];
 
-    [TwilioVoice configureAudioSession];
-    [self toggleAudioRoute:YES];
-    TwilioVoice.audioEnabled = NO;
+    self.audioDevice.enabled = NO;
+    self.audioDevice.block();
     
     [self.callKitProvider reportOutgoingCallWithUUID:action.callUUID startedConnectingAtDate:[NSDate date]];
     
@@ -379,14 +389,11 @@ withCompletionHandler:(void (^)(void))completion {
 - (void)provider:(CXProvider *)provider performAnswerCallAction:(CXAnswerCallAction *)action {
     NSLog(@"provider:performAnswerCallAction:");
 
-    // RCP: Workaround from https://forums.developer.apple.com/message/169511 suggests configuring audio in the
-    //      completion block of the `reportNewIncomingCallWithUUID:update:completion:` method instead of in
-    //      `provider:performAnswerCallAction:` per the WWDC examples.
-    // [[TwilioVoice sharedInstance] configureAudioSession];
-
     NSAssert([self.callInvite.uuid isEqual:action.callUUID], @"We only support one Invite at a time.");
     
-    TwilioVoice.audioEnabled = NO;
+    self.audioDevice.enabled = NO;
+    self.audioDevice.block();
+    
     [self performAnswerVoiceCallWithUUID:action.callUUID completion:^(BOOL success) {
         if (success) {
             [action fulfill];
@@ -408,6 +415,7 @@ withCompletionHandler:(void (^)(void))completion {
         [self.call disconnect];
     }
 
+    self.audioDevice.enabled = YES;
     [action fulfill];
 }
 
@@ -463,10 +471,6 @@ withCompletionHandler:(void (^)(void))completion {
     [self.callKitProvider reportNewIncomingCallWithUUID:uuid update:callUpdate completion:^(NSError *error) {
         if (!error) {
             NSLog(@"Incoming call successfully reported.");
-
-            // RCP: Workaround per https://forums.developer.apple.com/message/169511
-            [TwilioVoice configureAudioSession];
-            [self toggleAudioRoute:YES];
         }
         else {
             NSLog(@"Failed to report incoming call successfully: %@.", [error localizedDescription]);
@@ -495,18 +499,24 @@ withCompletionHandler:(void (^)(void))completion {
 - (void)performVoiceCallWithUUID:(NSUUID *)uuid
                           client:(NSString *)client
                       completion:(void(^)(BOOL success))completionHandler {
-    
-    self.call = [TwilioVoice call:[self fetchAccessToken]
-                           params:@{kTwimlParamTo: self.outgoingValue.text}
-                             uuid:uuid
-                         delegate:self];
+    __weak typeof(self) weakSelf = self;
+    TVOConnectOptions *connectOptions = [TVOConnectOptions optionsWithAccessToken:[self fetchAccessToken] block:^(TVOConnectOptionsBuilder *builder) {
+        __strong typeof(self) strongSelf = weakSelf;
+        builder.params = @{kTwimlParamTo: strongSelf.outgoingValue.text};
+        builder.uuid = uuid;
+    }];
+    self.call = [TwilioVoice connectWithOptions:connectOptions delegate:self];
     self.callKitCompletionCallback = completionHandler;
 }
 
 - (void)performAnswerVoiceCallWithUUID:(NSUUID *)uuid
                             completion:(void(^)(BOOL success))completionHandler {
-
-    self.call = [self.callInvite acceptWithDelegate:self];
+    __weak typeof(self) weakSelf = self;
+    TVOAcceptOptions *acceptOptions = [TVOAcceptOptions optionsWithCallInvite:self.callInvite block:^(TVOAcceptOptionsBuilder *builder) {
+        __strong typeof(self) strongSelf = weakSelf;
+        builder.uuid = strongSelf.callInvite.uuid;
+    }];
+    self.call = [self.callInvite acceptWithOptions:acceptOptions delegate:self];
     self.callInvite = nil;
     self.callKitCompletionCallback = completionHandler;
 }

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -292,16 +292,24 @@ withCompletionHandler:(void (^)(void))completion {
 #pragma mark - AVAudioSession
 - (void)toggleAudioRoute:(BOOL)toSpeaker {
     // The mode set by the Voice SDK is "VoiceChat" so the default audio route is the built-in receiver. Use port override to switch the route.
-    NSError *error = nil;
-    if (toSpeaker) {
-        if (![[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error]) {
-            NSLog(@"Unable to reroute audio: %@", [error localizedDescription]);
+    self.audioDevice.block =  ^ {
+        // We will execute `kDefaultAVAudioSessionConfigurationBlock` first.
+        kDefaultAVAudioSessionConfigurationBlock();
+        
+        // Overwrite the audio route
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        NSError *error = nil;
+        if (toSpeaker) {
+            if (![session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error]) {
+                NSLog(@"Unable to reroute audio: %@", [error localizedDescription]);
+            }
+        } else {
+            if (![session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error]) {
+                NSLog(@"Unable to reroute audio: %@", [error localizedDescription]);
+            }
         }
-    } else {
-        if (![[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error]) {
-            NSLog(@"Unable to reroute audio: %@", [error localizedDescription]);
-        }
-    }
+    };
+    self.audioDevice.block();
 }
 
 #pragma mark - Icon spinning

--- a/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ObjCVoiceQuickstart/ObjCVoiceQuickstart.entitlements;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.ObjCVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -329,7 +329,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ObjCVoiceQuickstart/ObjCVoiceQuickstart.entitlements;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.ObjCVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ObjCVoiceQuickstart/ObjCVoiceQuickstart.entitlements;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.ObjCVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -329,7 +329,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ObjCVoiceQuickstart/ObjCVoiceQuickstart.entitlements;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.ObjCVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVoiceQuickstart.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ObjCVoiceQuickstart/ObjCVoiceQuickstart.entitlements;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -326,6 +327,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ObjCVoiceQuickstart/ObjCVoiceQuickstart.entitlements;
 				INFOPLIST_FILE = ObjCVoiceQuickstart/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ObjCVoiceQuickstart/AppDelegate.m
+++ b/ObjCVoiceQuickstart/AppDelegate.m
@@ -15,7 +15,7 @@
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    NSLog(@"Twilio Voice Version: %@", [TwilioVoice version]);
+    NSLog(@"Twilio Voice Version: %@", [TwilioVoice sdkVersion]);
     [self configureUserNotifications];
 
     return YES;

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -43,8 +43,6 @@ typedef void (^RingtonePlaybackCallback)(void);
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
-    [TwilioVoice setLogLevel:TVOLogLevelAll];
 
     self.voipRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
     self.voipRegistry.delegate = self;

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -44,7 +44,7 @@ typedef void (^RingtonePlaybackCallback)(void);
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    [TwilioVoice setLogLevel:TVOLogLevelVerbose];
+    [TwilioVoice setLogLevel:TVOLogLevelAll];
 
     self.voipRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
     self.voipRegistry.delegate = self;
@@ -76,9 +76,10 @@ typedef void (^RingtonePlaybackCallback)(void);
         __weak typeof(self) weakSelf = self;
         [self playOutgoingRingtone:^{
             __strong typeof(self) strongSelf = weakSelf;
-            strongSelf.call = [TwilioVoice call:[strongSelf fetchAccessToken]
-                                         params:@{kTwimlParamTo: self.outgoingValue.text}
-                                       delegate:strongSelf];
+            TVOConnectOptions *connectOptions = [TVOConnectOptions optionsWithAccessToken:[strongSelf fetchAccessToken] block:^(TVOConnectOptionsBuilder *builder) {
+                builder.params = @{kTwimlParamTo: self.outgoingValue.text};
+            }];
+            strongSelf.call = [TwilioVoice connectWithOptions:connectOptions delegate:strongSelf];
         }];
         
         [self toggleUIState:NO showCallControl:NO];
@@ -239,7 +240,8 @@ withCompletionHandler:(void (^)(void))completion {
     UIAlertAction *accept = [UIAlertAction actionWithTitle:@"Accept" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         typeof(self) __strong strongSelf = weakSelf;
         [strongSelf stopIncomingRingtone];
-        strongSelf.call = [callInvite acceptWithDelegate:strongSelf];
+        TVOAcceptOptions *acceptOptions = [TVOAcceptOptions optionsWithCallInvite:strongSelf.callInvite];
+        strongSelf.call = [callInvite acceptWithOptions:acceptOptions delegate:strongSelf];
         strongSelf.callInvite = nil;
 
         strongSelf.incomingAlertController = nil;

--- a/Podfile
+++ b/Podfile
@@ -3,10 +3,10 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 2.0.0'
+  pod 'TwilioVoice', '3.0.0-preview1'
 
   target 'ObjCVoiceQuickstart' do
-    platform :ios, '8.1'
+    platform :ios, '10.0'
     project 'ObjCVoiceQuickstart.xcproject'
   end
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Twilio Voice Objective-C Quickstart for iOS
 
-> **Deprecation Notice - Versions 2.0.0-beta9 to 2.0.0-beta12**
->
-> Please note that **versions 2.0.0-beta9 to 2.0.0-beta12 of the Programmable Voice iOS library are deprecated and will stop working on September 13, 2018**. Please make sure you’re using the latest version of the library in your apps, and make sure your customers update their apps by that date. For more information please review the following knowledge base [article](https://support.twilio.com/hc/en-us/articles/360002897814-Legacy-Twilio-Programmable-Voice-SDKs-impacted-by-SSL-certificate-deprecation).
+> This is a developer preview release of the Programmable Voice 3.X SDK for iOS. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/changelog).
+> To use a generally available version of the Programmable Voice SDKs for iOS please see the [master](https://github.com/twilio/video-quickstart-swift/tree/master) branch based on the 2.X APIs.
 
 ## Get started with Voice on iOS:
 * [Quickstart](#quickstart) - Run the quickstart app

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ CXTransaction *transaction = [[CXTransaction alloc] initWithAction:setHeldCallAc
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/latest/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview1/docs)
 
 
 ## Twilio Helper Libraries


### PR DESCRIPTION
This pull request is to apply updates to accommodate API changes in Voice SDK 3.0.0-preview1. For more details, checkout the changelog of the [Programmable Voice iOS SDK](https://www.twilio.com/docs/voice/voip-sdk/ios/changelog).

Update for Voice iOS 3.0.0-preview1
- `[TwilioVoice version]` is now `[TwilioVoice sdkVersion]` to avoid method ambiguity with `NSObject`.
- Update log level.
- Use `TwilioVoice.audioDevice` and `TVODefaultAudioDevice` for AVAudioSession configuration and audio start/stop for CallKit integration.
- In `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` callback, fulfill the completion in the main queue to ensure the incoming call can be reported to CallKit and show the system call UI if the app was previously terminated.
- Use new connect/accept methods for connecting calls.