### PR TITLE
Dispatch the completion callback to the main queue

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -195,7 +195,9 @@ withCompletionHandler:(void (^)(void))completion {
                                delegate:self];
     }
 
-    completion();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion();
+    })
 }
 
 #pragma mark - TVONotificationDelegate

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -179,7 +179,9 @@ withCompletionHandler:(void (^)(void))completion {
                                delegate:self];
     }
     
-    completion();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion();
+    })
 }
 
 #pragma mark - TVONotificationDelegate


### PR DESCRIPTION
To ensure good background experience, especially when the app was terminated, dispatch the didReceiveIncomingPush completion to the main queue so that the (CallKit) can be properly shown.