### PR TITLE
Updates for 3.0.0-preview3

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -211,23 +211,13 @@ withCompletionHandler:(void (^)(void))completion {
 
 #pragma mark - TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
-    [self handleCallInviteReceived:callInvite];
-}
-
-- (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
-    [self handleCallInviteCancelled:cancelledCallInvite];
-}
-
-- (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteReceived:");
     
     if (self.callInvite) {
-        NSLog(@"Already a pending incoming call invite.");
-        NSLog(@"  >> Ignoring call from %@", callInvite.from);
+        NSLog(@"A callInvite is already in progress. Ignoring the incoming call invite from %@", callInvite.from);
         return;
     } else if (self.call) {
-        NSLog(@"Already an active call.");
-        NSLog(@"  >> Ignoring call from %@", callInvite.from);
+        NSLog(@"Already an active call. Ignoring the incoming call invite from %@", callInvite.from);
         return;
     }
 
@@ -236,8 +226,14 @@ withCompletionHandler:(void (^)(void))completion {
     [self reportIncomingCallFrom:@"Voice Bot" withUUID:callInvite.uuid];
 }
 
-- (void)handleCallInviteCancelled:(TVOCancelledCallInvite *)callInvite {
+- (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
     NSLog(@"handleCallInviteCancelled:");
+    
+    if (!self.callInvite ||
+        ![self.callInvite.callSid isEqualToString:cancelledCallInvite.callSid]) {
+        NSLog(@"No matching pending Call Invite. Ignoring the Cancelled Call Invite");
+        return;
+    }
 
     [self performEndCallActionWithUUID:self.callInvite.uuid];
 

--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -214,10 +214,10 @@ withCompletionHandler:(void (^)(void))completion {
     NSLog(@"callInviteReceived:");
     
     if (self.callInvite) {
-        NSLog(@"A callInvite is already in progress. Ignoring the incoming call invite from %@", callInvite.from);
+        NSLog(@"A CallInvite is already in progress. Ignoring the incoming CallInvite from %@", callInvite.from);
         return;
     } else if (self.call) {
-        NSLog(@"Already an active call. Ignoring the incoming call invite from %@", callInvite.from);
+        NSLog(@"Already an active call. Ignoring the incoming CallInvite from %@", callInvite.from);
         return;
     }
 
@@ -227,11 +227,11 @@ withCompletionHandler:(void (^)(void))completion {
 }
 
 - (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
-    NSLog(@"handleCallInviteCancelled:");
+    NSLog(@"cancelledCallInviteReceived:");
     
     if (!self.callInvite ||
         ![self.callInvite.callSid isEqualToString:cancelledCallInvite.callSid]) {
-        NSLog(@"No matching pending Call Invite. Ignoring the Cancelled Call Invite");
+        NSLog(@"No matching pending CallInvite. Ignoring the Cancelled CallInvite");
         return;
     }
 

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -159,8 +159,9 @@ typedef void (^RingtonePlaybackCallback)(void);
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
     if ([type isEqualToString:PKPushTypeVoIP]) {
-        [TwilioVoice handleNotification:payload.dictionaryPayload
-                               delegate:self];
+        if (![TwilioVoice handleNotification:payload.dictionaryPayload delegate:self]) {
+            NSLog(@"This is not a valid Twilio Voice notification.");
+        }
     }
 }
 
@@ -174,8 +175,9 @@ didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
 withCompletionHandler:(void (^)(void))completion {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:");
     if ([type isEqualToString:PKPushTypeVoIP]) {
-        [TwilioVoice handleNotification:payload.dictionaryPayload
-                               delegate:self];
+        if (![TwilioVoice handleNotification:payload.dictionaryPayload delegate:self]) {
+            NSLog(@"This is not a valid Twilio Voice notification.");
+        }
     }
     
     completion();
@@ -183,17 +185,17 @@ withCompletionHandler:(void (^)(void))completion {
 
 #pragma mark - TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
-    if (callInvite.state == TVOCallInviteStatePending) {
-        [self handleCallInviteReceived:callInvite];
-    } else if (callInvite.state == TVOCallInviteStateCanceled) {
-        [self handleCallInviteCanceled:callInvite];
-    }
+    [self handleCallInviteReceived:callInvite];
+}
+
+- (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
+    [self handleCallInviteCancelled:cancelledCallInvite];
 }
 
 - (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteReceived:");
     
-    if (self.callInvite && self.callInvite.state == TVOCallInviteStatePending) {
+    if (self.callInvite) {
         NSLog(@"Already a pending call invite. Ignoring incoming call invite from %@", callInvite.from);
         return;
     }
@@ -260,8 +262,8 @@ withCompletionHandler:(void (^)(void))completion {
     }
 }
 
-- (void)handleCallInviteCanceled:(TVOCallInvite *)callInvite {
-    NSLog(@"callInviteCanceled:");
+- (void)handleCallInviteCancelled:(TVOCancelledCallInvite *)callInvite {
+    NSLog(@"handleCallInviteCancelled:");
     
     if (![callInvite.callSid isEqualToString:self.callInvite.callSid]) {
         NSLog(@"Incoming (but not current) call invite from \"%@\" canceled. Just ignore it.", callInvite.from);
@@ -284,10 +286,6 @@ withCompletionHandler:(void (^)(void))completion {
     self.callInvite = nil;
 
     [[UIApplication sharedApplication] cancelAllLocalNotifications];
-}
-
-- (void)notificationError:(NSError *)error {
-    NSLog(@"notificationError: %@", [error localizedDescription]);
 }
 
 #pragma mark - TVOCallDelegate

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -185,18 +185,10 @@ withCompletionHandler:(void (^)(void))completion {
 
 #pragma mark - TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
-    [self handleCallInviteReceived:callInvite];
-}
-
-- (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
-    [self handleCallInviteCancelled:cancelledCallInvite];
-}
-
-- (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteReceived:");
     
     if (self.callInvite) {
-        NSLog(@"Already a pending call invite. Ignoring incoming call invite from %@", callInvite.from);
+        NSLog(@"A callInvite is already in progress. Ignoring the incoming call invite from %@", callInvite.from);
         return;
     }
     if (self.call && self.call.state == TVOCallStateConnected) {
@@ -262,11 +254,12 @@ withCompletionHandler:(void (^)(void))completion {
     }
 }
 
-- (void)handleCallInviteCancelled:(TVOCancelledCallInvite *)callInvite {
+- (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
     NSLog(@"handleCallInviteCancelled:");
     
-    if (![callInvite.callSid isEqualToString:self.callInvite.callSid]) {
-        NSLog(@"Incoming (but not current) call invite from \"%@\" canceled. Just ignore it.", callInvite.from);
+    if (!self.callInvite ||
+        ![self.callInvite.callSid isEqualToString:cancelledCallInvite.callSid]) {
+        NSLog(@"No matching pending Call Invite. Ignoring the Cancelled Call Invite");
         return;
     }
     

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -188,11 +188,11 @@ withCompletionHandler:(void (^)(void))completion {
     NSLog(@"callInviteReceived:");
     
     if (self.callInvite) {
-        NSLog(@"A callInvite is already in progress. Ignoring the incoming call invite from %@", callInvite.from);
+        NSLog(@"A CallInvite is already in progress. Ignoring the incoming CallInvite from %@", callInvite.from);
         return;
     }
     if (self.call && self.call.state == TVOCallStateConnected) {
-        NSLog(@"Already an active call. Ignoring incoming call invite from %@", callInvite.from);
+        NSLog(@"Already an active call. Ignoring incoming CallInvite from %@", callInvite.from);
         return;
     }
     
@@ -255,11 +255,11 @@ withCompletionHandler:(void (^)(void))completion {
 }
 
 - (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
-    NSLog(@"handleCallInviteCancelled:");
+    NSLog(@"cancelledCallInviteReceived:");
     
     if (!self.callInvite ||
         ![self.callInvite.callSid isEqualToString:cancelledCallInvite.callSid]) {
-        NSLog(@"No matching pending Call Invite. Ignoring the Cancelled Call Invite");
+        NSLog(@"No matching pending CallInvite. Ignoring the Cancelled CallInvite");
         return;
     }
     

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-preview2'
+  pod 'TwilioVoice', '3.0.0-preview3'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '10.0'

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ CXTransaction *transaction = [[CXTransaction alloc] initWithAction:setHeldCallAc
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview2/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview3/docs)
 
 
 ## Twilio Helper Libraries


### PR DESCRIPTION
- Use `3.0.0-preview3` in `Podfile`.
- Adopt the new `TVOCallInvite` and `TVOCancelledCallInvite` object model.
  - `TVOCallInviteState` is removed and the new `TVOCancelledCallInvite` object is introduced.
- Adopt the new `TVONotificationDelegate`
  - `notificationError:` has been removed in `3.0.0-preview3`.
  - `cancelledCallInviteReceived:` method added for `TVOCancelledCallInvite`.