### PR TITLE
Fix end-call flow to avoid unknown UUID error

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -92,7 +92,7 @@ static NSString *const kTwimlParamTo = @"to";
 
 - (IBAction)placeCall:(id)sender {
     if (self.call && self.call.state == TVOCallStateConnected) {
-        [self.call disconnect];
+        [self performEndCallActionWithUUID:self.call.uuid];
         [self toggleUIState:NO showCallControl:NO];
     } else {
         NSUUID *uuid = [NSUUID UUID];
@@ -265,8 +265,7 @@ withCompletionHandler:(void (^)(void))completion {
     } else {
         NSLog(@"Call disconnected");
     }
-    
-    [self performEndCallActionWithUUID:call.uuid];
+
     [self callDisconnected];
 }
 


### PR DESCRIPTION
Update the end-call flow to avoid requesting the end-call action twice.
Related issue: https://github.com/twilio/voice-quickstart-swift/issues/155