### PR TITLE
(3.x) Fix end-call flow to avoid unknown UUID error 

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -99,7 +99,7 @@ static NSString *const kTwimlParamTo = @"to";
 
 - (IBAction)placeCall:(id)sender {
     if (self.call && self.call.state == TVOCallStateConnected) {
-        [self.call disconnect];
+        [self performEndCallActionWithUUID:self.call.uuid];
         [self toggleUIState:NO showCallControl:NO];
     } else {
         NSUUID *uuid = [NSUUID UUID];
@@ -269,8 +269,7 @@ withCompletionHandler:(void (^)(void))completion {
     } else {
         NSLog(@"Call disconnected");
     }
-    
-    [self performEndCallActionWithUUID:call.uuid];
+
     [self callDisconnected];
 }
 


### PR DESCRIPTION
Update the end-call flow to avoid requesting the end-call action twice.
Related issue: #155 