### PR TITLE
Add microphone permission guideline in the migration guide

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -113,7 +113,8 @@ static NSString *const kTwimlParamTo = @"to";
 
                 typeof(self) __weak weakSelf = self;
                 UIAlertAction *continueWithoutMic = [UIAlertAction actionWithTitle:@"Continue without microphone"
-                                                                             style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                                                                             style:UIAlertActionStyleDefault
+                                                                           handler:^(UIAlertAction *action) {
                     typeof(self) __strong strongSelf = weakSelf;
                     [strongSelf performStartCallActionWithUUID:uuid handle:handle];
                 }];
@@ -121,7 +122,8 @@ static NSString *const kTwimlParamTo = @"to";
 
                 NSDictionary *openURLOptions = @{UIApplicationOpenURLOptionUniversalLinksOnly: @NO};
                 UIAlertAction *goToSettings = [UIAlertAction actionWithTitle:@"Settings"
-                                                                       style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                                                                       style:UIAlertActionStyleDefault
+                                                                     handler:^(UIAlertAction *action) {
                     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
                                                        options:openURLOptions
                                              completionHandler:nil];
@@ -129,7 +131,8 @@ static NSString *const kTwimlParamTo = @"to";
                 [alertController addAction:goToSettings];
                 
                 UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel"
-                                                                 style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+                                                                 style:UIAlertActionStyleCancel
+                                                               handler:^(UIAlertAction *action) {
                     typeof(self) __strong strongSelf = weakSelf;
                     [strongSelf toggleUIState:YES showCallControl:NO];
                     [strongSelf stopSpin];

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -84,7 +84,8 @@ typedef void (^RingtonePlaybackCallback)(void);
 }
 
 - (void)makeCall:(NSString *)to {
-    TVOConnectOptions *connectOptions = [TVOConnectOptions optionsWithAccessToken:[self fetchAccessToken] block:^(TVOConnectOptionsBuilder *builder) {
+    TVOConnectOptions *connectOptions = [TVOConnectOptions optionsWithAccessToken:[self fetchAccessToken]
+                                                                            block:^(TVOConnectOptionsBuilder *builder) {
         builder.params = @{kTwimlParamTo: to};
     }];
 
@@ -97,14 +98,16 @@ typedef void (^RingtonePlaybackCallback)(void);
                                                                               preferredStyle:UIAlertControllerStyleAlert];
 
             UIAlertAction *continueWithoutMic = [UIAlertAction actionWithTitle:@"Continue without microphone"
-                                                                         style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                                                                         style:UIAlertActionStyleDefault
+                                                                       handler:^(UIAlertAction *action) {
                 strongSelf.call = [TwilioVoice connectWithOptions:connectOptions delegate:strongSelf];
             }];
             [alertController addAction:continueWithoutMic];
             
             NSDictionary *openURLOptions = @{UIApplicationOpenURLOptionUniversalLinksOnly: @NO};
             UIAlertAction *goToSettings = [UIAlertAction actionWithTitle:@"Settings"
-                                                                   style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                                                                   style:UIAlertActionStyleDefault
+                                                                 handler:^(UIAlertAction *action) {
                 [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
                                                    options:openURLOptions
                                          completionHandler:nil];
@@ -112,7 +115,8 @@ typedef void (^RingtonePlaybackCallback)(void);
             [alertController addAction:goToSettings];
             
             UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel"
-                                                             style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+                                                             style:UIAlertActionStyleCancel
+                                                           handler:^(UIAlertAction *action) {
                 [strongSelf toggleUIState:YES showCallControl:NO];
                 [strongSelf stopSpin];
             }];

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ An example of managing the `TVODefaultAudioDevice` while connecting a CallKit Ca
 See [CallKit Example](https://github.com/twilio/voice-quickstart-objc/blob/3.x/ObjCVoiceCallKitQuickstart/ViewController.m) for the complete implementation.
 
 #### <a name="microphone-permission"></a>Microphone Permission
-Unlike Voice iOS 2.X SDKs where microphone permission is not optional in Voice 3.X SDKs, the call will connect even when the microphone permission is denied or disabled by the user. To ensure the microphone permission is enabled prior to making or accepting a call you can add the following to request permission beforehand:
+Unlike Voice iOS 2.X SDKs where microphone permission is not optional in Voice 3.X SDKs, the call will connect even when the microphone permission is denied or disabled by the user. To ensure the microphone permission is enabled prior to making or accepting a call you can add the following to request the permission beforehand:
 
 ```
 - (void)makeCall {

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ An example of managing the `TVODefaultAudioDevice` while connecting a CallKit Ca
 See [CallKit Example](https://github.com/twilio/voice-quickstart-objc/blob/3.x/ObjCVoiceCallKitQuickstart/ViewController.m) for the complete implementation.
 
 #### <a name="microphone-permission"></a>Microphone Permission
-Unlike Voice iOS 2.X SDKs where microphone permission is not optional in Voice 3.X SDKs, the call will connect even when the microphone permission is denied or disabled by the user. To ensure the microphone permission is enabled prior to making or accepting a call you can add the following to request the permission beforehand:
+Unlike Voice iOS 2.X SDKs where microphone permission is not optional in Voice 3.X SDKs, the call will connect even when the microphone permission is denied or disabled by the user, and the SDK will play the remote audio. To ensure the microphone permission is enabled prior to making or accepting a call you can add the following to request the permission beforehand:
 
 ```
 - (void)makeCall {

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ This section describes API or behavioral changes when upgrading from Voice iOS 2
 4. [TVOConnectOptions & TVOAcceptOptions](#tvoconnectoptions-and-tvoacceptoptions)
 5. [Media Establishment & Connectivity](#media-establishment-and-connectivity)
 6. [CallKit](#callkit)
+7. [Microphone Permission](#microphone-permission)
 
 #### <a name="making-a-call"></a>Making a Call
 In Voice iOS 3.X, the API to make a call has changed from `[TwilioVoice call:params:delegate:]` to `[TwilioVoice connectWithAccessToken:delegate]` or `[TwilioVoice connectWithOptions:delegate:]`.
@@ -532,6 +533,54 @@ An example of managing the `TVODefaultAudioDevice` while connecting a CallKit Ca
 ```
 
 See [CallKit Example](https://github.com/twilio/voice-quickstart-objc/blob/3.x/ObjCVoiceCallKitQuickstart/ViewController.m) for the complete implementation.
+
+#### <a name="microphone-permission"></a>Microphone Permission
+Microphone permission is not optional in the Voice iOS 2.X SDK. Permission must be granted by the user in addition to the usage description being presented in the plist file. Error will be raised when making or accepting calls without microphone permission granted. In the Voice iOS 3.X SDK will continue to connect the call even when the microphone permission is denied or disabled by the user. The application needs to check record permission prior to connecting a call and provide proper experience to the users.
+
+```
+- (void)makeCall {
+    // User's microphone option
+    BOOL microphoneEnabled = YES;
+    
+    if (microphoneEnabled) {
+        [self checkRecordPermission:^(BOOL permissionGranted) {
+            if (!permissionGranted) {
+                // The user might want to revisit the Privacy settings.
+            } else {
+                // Permission granted. Continue to make call.
+            }
+        }];
+    } else {
+        // Continue to make call without microphone.
+    }
+}
+
+- (void)checkRecordPermission:(void(^)(BOOL permissionGranted))completion {
+    AVAudioSessionRecordPermission permissionStatus = [[AVAudioSession sharedInstance] recordPermission];
+    switch (permissionStatus) {
+        case AVAudioSessionRecordPermissionGranted:
+            // Record permission already granted.
+            completion(YES);
+            break;
+        case AVAudioSessionRecordPermissionDenied:
+            // Record permission denied.
+            completion(NO);
+            break;
+        case AVAudioSessionRecordPermissionUndetermined:
+        {
+            // Requesting record permission.
+            // Optional: pop up app dialog to let the users know if they want to request.
+            [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+                completion(granted);
+            }];
+            break;
+        }
+        default:
+            completion(NO);
+            break;
+    }
+}
+```
 
 ## Managing Audio Interruptions
 Different versions of iOS deal with **AVAudioSession** interruptions sightly differently. This section documents how the Programmable Voice iOS SDK manages audio interruptions and resumes call audio after the interruption ends. There are currently some cases that the SDK cannot resume call audio automatically because iOS does not provide the necessary notifications to indicate that the interruption has ended.

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ An example of managing the `TVODefaultAudioDevice` while connecting a CallKit Ca
 See [CallKit Example](https://github.com/twilio/voice-quickstart-objc/blob/3.x/ObjCVoiceCallKitQuickstart/ViewController.m) for the complete implementation.
 
 #### <a name="microphone-permission"></a>Microphone Permission
-Microphone permission is not optional in the Voice iOS 2.X SDK. Permission must be granted by the user in addition to the usage description being presented in the plist file. Error will be raised when making or accepting calls without microphone permission granted. In the Voice iOS 3.X SDK will continue to connect the call even when the microphone permission is denied or disabled by the user. The application needs to check record permission prior to connecting a call and provide proper experience to the users.
+Unlike Voice iOS 2.X SDKs where microphone permission is not optional in Voice 3.X SDKs, the call will connect even when the microphone permission is denied or disabled by the user. To ensure the microphone permission is enabled prior to making or accepting a call you can add the following to request permission beforehand:
 
 ```
 - (void)makeCall {


### PR DESCRIPTION
Add a section in the migration guide for requesting microphone permission in the apps using 3.x SDK.