### PR TITLE
Call the incoming push completion handler when call reported to CallKit

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -305,6 +305,8 @@ withCompletionHandler:(void (^)(void))completion {
 - (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
     NSLog(@"cancelledCallInviteReceived:");
     
+    [self incomingPushHandled];
+    
     if (!self.callInvite ||
         ![self.callInvite.callSid isEqualToString:cancelledCallInvite.callSid]) {
         NSLog(@"No matching pending CallInvite. Ignoring the Cancelled CallInvite");
@@ -560,7 +562,6 @@ withCompletionHandler:(void (^)(void))completion {
         else {
             NSLog(@"Failed to report incoming call successfully: %@.", [error localizedDescription]);
         }
-        [self incomingPushHandled];
     }];
 }
 
@@ -575,7 +576,6 @@ withCompletionHandler:(void (^)(void))completion {
         else {
             NSLog(@"EndCallAction transaction request successful");
         }
-        [self incomingPushHandled];
     }];
 }
 
@@ -609,6 +609,7 @@ withCompletionHandler:(void (^)(void))completion {
     }
     
     self.callInvite = nil;
+    [self incomingPushHandled];
 }
 
 @end

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -348,8 +348,6 @@ withCompletionHandler:(void (^)(void))completion {
 - (void)cancelledCallInviteReceived:(TVOCancelledCallInvite *)cancelledCallInvite {
     NSLog(@"cancelledCallInviteReceived:");
     
-    [self incomingPushHandled];
-    
     if (!self.callInvite ||
         ![self.callInvite.callSid isEqualToString:cancelledCallInvite.callSid]) {
         NSLog(@"No matching pending CallInvite. Ignoring the Cancelled CallInvite");
@@ -372,6 +370,8 @@ withCompletionHandler:(void (^)(void))completion {
     self.callInvite = nil;
 
     [[UNUserNotificationCenter currentNotificationCenter] removeAllPendingNotificationRequests];
+    
+    [self incomingPushHandled];
 }
 
 #pragma mark - TVOCallDelegate

--- a/ObjCVoiceQuickstart/ViewController.m
+++ b/ObjCVoiceQuickstart/ViewController.m
@@ -268,10 +268,12 @@ withCompletionHandler:(void (^)(void))completion {
     
     if (self.callInvite) {
         NSLog(@"A CallInvite is already in progress. Ignoring the incoming CallInvite from %@", callInvite.from);
+        [self incomingPushHandled];
         return;
     }
     if (self.call && self.call.state == TVOCallStateConnected) {
         NSLog(@"Already an active call. Ignoring incoming CallInvite from %@", callInvite.from);
+        [self incomingPushHandled];
         return;
     }
     


### PR DESCRIPTION
the updates is to fix an issue where CallKit calls are not properly shown to the users when the app is in the background or terminated. The issue happens when reporting the call to CallKit and calling the incoming-push completion handler at the same time (when the app is not in the foreground). For some reason the CallKit reporting method gets stuck and won't fire the completion block in this scenario. The fix relieves the problem by only calling the incoming-push-completion when the call is reported.

Save the completion handler of the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method and call when the call is properly reported to CallKit.