### PR TITLE
Update for 3.0.0-beta2 release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-beta1'
+  pod 'TwilioVoice', '3.0.0-beta2'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '10.0'

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Voice iOS 3.X has a number of new features listed below:
 5. [Audio Device APIs](#audio-device-apis)
     * [Default Audio Device](#default-audio-device)
     * [Custom Audio Device](#custom-audio-device)
+6. [Preferred Audio Codec](#preferred-audio-codec)
 
 #### <a name="webrtc"></a>WebRTC
 The SDK is built using Chromium WebRTC for iOS. This ensures that over time developers will get the best real-time media streaming capabilities available for iOS. Additionally, upgrades to new versions of Chromium WebRTC will happen without changing the public API whenever possible.
@@ -355,6 +356,20 @@ id<TVOAudioDevice> audioDevice = [TVODefaultAudioDevice audioDeviceWithBlock:^ {
 TwilioVoice.audioDevice = audioDevice;
 
 TVOCall *call = [TwilioVoice connectWithOptions:connectOptions delegate:self];
+```
+
+### <a name="preferred-audio-codec"></a>Preferred Audio Codec
+In Voice iOS 3.X, you can provide your preferred audio codec in the `TVOConnectOptions` and the `TVOAcceptOptions`.
+
+```.objc
+#import "TVOAudioCodec.h"
+
+TVOConnectOptions *options = [TVOConnectOptions optionsWithAccessToken:accessToken
+                                                                 block:^(TVOConnectOptionsBuilder *builder) {
+    builder.preferredAudioCodecs = @[ [TVOOpusCodec new], [TVOPcmuCodec new] ];
+}];
+
+self.call = [TwilioVoice connectWithOptions:options delegate:self];
 ```
 
 ## Migration Guide

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ CXTransaction *transaction = [[CXTransaction alloc] initWithAction:setHeldCallAc
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta1/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta2/docs)
 
 
 ## Twilio Helper Libraries

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ TVOCall *call = [TwilioVoice connectWithOptions:connectOptions delegate:self];
 
 ### <a name="preferred-audio-codec"></a>Preferred Audio Codec
 In Voice iOS 3.X, you can provide your preferred audio codec in the `TVOConnectOptions` and the `TVOAcceptOptions`.
+The only audio codec supported by our mobile infrastructure is currently PCMU. Opus is not currently available on our mobile infrastructure. However it will become available in Q1 of 2019. At that point the default audio codec for all 3.X mobile clients will be Opus. To always use PCMU as the negotiated audio codec instead you can add it as the first codec in the `preferAudioCodecs` list.
 
 ```.objc
 #import "TVOAudioCodec.h"


### PR DESCRIPTION
- Use Voice iOS `3.0.0-beta2`
- Add sample code for specifying preferred audio codec