### PR TITLE
Call the incoming push completion handler when the call is reported to CallKit

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -239,10 +239,10 @@ withCompletionHandler:(void (^)(void))completion {
 
 - (void)handleCallInviteCanceled:(TVOCallInvite *)callInvite {
     NSLog(@"callInviteCanceled:");
-    
-    [self incomingPushHandled];
+
     [self performEndCallActionWithUUID:callInvite.uuid];
     self.callInvite = nil;
+    [self incomingPushHandled];
 }
 
 - (void)notificationError:(NSError *)error {
@@ -519,8 +519,8 @@ withCompletionHandler:(void (^)(void))completion {
 
     self.call = [self.callInvite acceptWithDelegate:self];
     self.callInvite = nil;
-    [self incomingPushHandled];
     self.callKitCompletionCallback = completionHandler;
+    [self incomingPushHandled];
 }
 
 @end


### PR DESCRIPTION
the updates is to fix an issue where CallKit calls are not properly shown to the users when the app is in the background or terminated. The issue happens when reporting the call to CallKit and calling the incoming-push completion handler at the same time (when the app is not in the foreground). For some reason the CallKit reporting method gets stuck and won't fire the completion block in this scenario. The fix relieves the problem by only calling the incoming-push-completion when the call is reported.

Save the completion handler of the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method and call when the call is properly reported to CallKit and handled.