### PR TITLE
Use Voice iOS 3.0.0-beta10

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "twilio/twilio-voice-ios" "3.0.0-beta9"
+github "twilio/twilio-voice-ios" "3.0.0-beta10"
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-beta9'
+  pod 'TwilioVoice', '3.0.0-beta10'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '10.0'

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Please ensure that after deleting the Push Credential you remove or replace the 
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta9/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta10/docs)
 
 
 ## Twilio Helper Libraries


### PR DESCRIPTION
Bug Fixes

- CLIENT-5828, CLIENT-5868 A network change that occurs during a reconnection will now trigger another reconnection attempt ensuring media is restored on the correct network.
- CLIENT-5882 Call metrics insights will always be available after a network handover when the call is in `TVOCallStateConnected` state.

Known Issues

- CLIENT-5576 LTE -> WiFi may cause one way audio.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).

Size Report

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 5.8 MB | 12.4 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB