### PR TITLE
Use Voice iOS 3.0.0-beta12

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "twilio/twilio-voice-ios" "3.0.0-beta11"
+github "twilio/twilio-voice-ios" "3.0.0-beta12"
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-beta11'
+  pod 'TwilioVoice', '3.0.0-beta12'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '10.0'

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Please ensure that after deleting the Push Credential you remove or replace the 
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta11/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta12/docs)
 
 
 ## Twilio Helper Libraries


### PR DESCRIPTION
Enhancements

- CLIENT-5973 Removed `TVOErrorConnectionTimeoutError`, `TVOErrorSignalingConnectionError`, `TVOErrorSignalingConnectionTimeoutError`, `TVOErrorSignalingIncomingMessageInvalidError`, `TVOErrorSignalingOutgoingMessageInvalidError`, `TVOErrorConfigurationAcquireFailedError` and `TVOErrorConfigurationAcquireTurnFailedError` from `TVOError.h`.

Bug Fixes

- CLIENT-5935 Fixed a bug where constant audio level warning events are being sent to Insights when the call is muted or onhold.
- CLIENT-5969 Renamed `kDefaultAVAudioSessionConfigurationBlock` to `kTVODefaultAVAudioSessionConfigurationBlock` so that `TwilioVoice.framework` and `TwilioVideo.framework` may be used in the same application.
- CLIENT-5977 Fixed a bug where the SDK was sending double values for `packets_lost_fraction` to Insights instead of integer.

Known Issues

- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).

Size Report

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 5.8 MB | 12.3 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB