### PR TITLE
Use Voice iOS 4.2.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "twilio/twilio-voice-ios" >= 4.0.0
+github "twilio/twilio-voice-ios" >= 4.2.0
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 4.1'
+  pod 'TwilioVoice', '~> 4.2'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '10.0'


### PR DESCRIPTION
Enhancements

- CLIENT-6420 The static library dependencies are now embedded in `libTwilioVoice.a`
- The `libboringssl.a` library is now separated and shipped alongside the static library `libTwilioVoice.a`. Add `-lboringssl` in the **Other Linker Flags** to link the SDK properly.
- CLIENT-6438 Added `customParameters` property to `TVOCancelledCallInvite`.

Pass custom parameters in TwiML
```xml
  <?xml version="1.0" encoding="UTF-8"?>
  <Response>
    <Dial callerId="client:alice">
      <Client>
        <Identity>bob</Identity>
        <Parameter name="caller_first_name" value="alice" />
        <Parameter name="caller_last_name" value="smith" />
      </Client>
    </Dial>
  </Response>
```

`cancelledCallInvite.customParameters`:
```objc
  {
    "caller_first_name" = "alice";
    "caller_last_name" = "smith";
  }
```

Known Issues

- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).