### PR TITLE
Updates for Voice iOS 2.1.0

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -22,7 +22,6 @@ static NSString *const kTwimlParamTo = @"to";
 @property (nonatomic, strong) NSString *deviceTokenString;
 
 @property (nonatomic, strong) PKPushRegistry *voipRegistry;
-@property (nonatomic, strong) void(^incomingPushCompletionCallback)(void);
 @property (nonatomic, strong) TVOCallInvite *callInvite;
 @property (nonatomic, strong) TVOCall *call;
 @property (nonatomic, strong) void(^callKitCompletionCallback)(BOOL);
@@ -135,7 +134,11 @@ static NSString *const kTwimlParamTo = @"to";
     NSLog(@"pushRegistry:didUpdatePushCredentials:forType:");
 
     if ([type isEqualToString:PKPushTypeVoIP]) {
-        self.deviceTokenString = [credentials.token description];
+        const unsigned *tokenBytes = [credentials.token bytes];
+        self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>",
+                                  ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
+                                  ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
+                                  ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
         NSString *accessToken = [self fetchAccessToken];
 
         [TwilioVoice registerWithAccessToken:accessToken
@@ -194,27 +197,33 @@ didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
 withCompletionHandler:(void (^)(void))completion {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:");
 
-    // Save for later when the notification is properly handled.
-    self.incomingPushCompletionCallback = completion;
-
     if ([type isEqualToString:PKPushTypeVoIP]) {
         [TwilioVoice handleNotification:payload.dictionaryPayload
                                delegate:self];
     }
-}
-
-- (void)incomingPushHandled {
-    if (self.incomingPushCompletionCallback) {
-        self.incomingPushCompletionCallback();
-        self.incomingPushCompletionCallback = nil;
-    }
+    
+    /**
+     * The Voice SDK processes the call notification and returns the call invite synchronously. Report the incoming call to
+     * CallKit and fulfill the completion before exiting this callback method.
+    */
+    completion();
 }
 
 #pragma mark - TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
     if (callInvite.state == TVOCallInviteStatePending) {
+        /**
+         * Calling `[TwilioVoice handleNotification:]` will synchronously process your notification payload and
+         * provide you a `TVOCallInvite` object with `TVOCallInviteStatePending` state.
+         * Report the incoming call to CallKit upon receiving this callback.
+         */
         [self handleCallInviteReceived:callInvite];
     } else if (callInvite.state == TVOCallInviteStateCanceled) {
+        /**
+         * The SDK may call `[TVONotificationDelegate callInviteReceived:]` asynchronously on the main dispatch queue
+         * with a `TVOCallInvite` state of `TVOCallInviteStateCanceled` if the caller hangs up or the client
+         * encounters any other error before the called party could answer or reject the call.
+         */
         [self handleCallInviteCanceled:callInvite];
     }
 }
@@ -225,12 +234,10 @@ withCompletionHandler:(void (^)(void))completion {
     if (self.callInvite && self.callInvite == TVOCallInviteStatePending) {
         NSLog(@"Already a pending incoming call invite.");
         NSLog(@"  >> Ignoring call from %@", callInvite.from);
-        [self incomingPushHandled];
         return;
     } else if (self.call) {
         NSLog(@"Already an active call.");
         NSLog(@"  >> Ignoring call from %@", callInvite.from);
-        [self incomingPushHandled];
         return;
     }
 
@@ -244,7 +251,6 @@ withCompletionHandler:(void (^)(void))completion {
 
     [self performEndCallActionWithUUID:callInvite.uuid];
     self.callInvite = nil;
-    [self incomingPushHandled];
 }
 
 - (void)notificationError:(NSError *)error {
@@ -532,7 +538,6 @@ withCompletionHandler:(void (^)(void))completion {
     self.call = [self.callInvite acceptWithDelegate:self];
     self.callInvite = nil;
     self.callKitCompletionCallback = completionHandler;
-    [self incomingPushHandled];
 }
 
 @end

--- a/ObjCVoiceQuickstart/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ObjCVoiceQuickstart/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -139,6 +139,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-83.5@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 2.0.0'
+  pod 'TwilioVoice', '~> 2.1.0'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '8.1'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,68 @@
 # Twilio Voice Objective-C Quickstart for iOS
 
-> NOTE: These sample applications use the Twilio Voice 2.x APIs. If you are using SDK 2.x, we highly recommend planning your migration to 3.0 as soon as possible. Support for 2.x will cease 1/1/2020. Until then, SDK 2.x will only receive fixes for critical or security related issues. For examples using our 3.x APIs, please see the [master](https://github.com/twilio/voice-quickstart-objc/tree/master) branch.
+> Note: If you plan to build your apps using Xcode 11 and deploy on iOS 13 devices, please use the `ObjCVoiceCallKitQuickstart` sample app. Reporting new incoming calls to CallKit upon receiving VoIP push notifications is mandated by Apple's new [PushKit push notification policy](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry). Failure to integrate the CallKit framework will result in runtime exceptions.
+
+## Migrating to Voice iOS 2.1.0 for iOS 13 Compatibility
+
+The Voice iOS 2.1.0 release adds support for the new [PushKit push notification policy](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry) that iOS 13 and Xcode 11 introduced.
+
+This new policy mandates that Apps built with Xcode 11 and running on iOS 13, which receive VoIP push notifications, must now report all PushKit push notifications to CallKit. Failure to do so will result in iOS 13 terminating the App and barring any further PushKit push notifications. You can read more about this policy and breaking changes [here](https://support.twilio.com/hc/en-us/articles/360035005593-iOS-13-Xcode-11-Breaking-Changes).
+
+The SDK now handles incoming call cancellations internally. The “cancel” push notification is no longer required or supported by this release of the SDK.
+
+If your App supports incoming calls, you **MUST** perform the following steps to comply with the new policy:
+
+- Upgrade to Twilio Voice iOS SDK to 2.1.0
+- Report the call to CallKit. Refer to this [example](https://github.com/twilio/voice-quickstart-objc/tree/2.x) for how to report the call to CallKit.
+- Update how you decode the PushKit token
+
+Swift
+
+```.swift
+func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
+    ...
+    let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()
+    ...
+}
+```
+
+Objective-C
+
+```.objc
+- (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type {
+    ...
+    const unsigned *tokenBytes = [credentials.token bytes];
+    self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>", 
+                                                        ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
+                                                        ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
+                                                        ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
+    ...
+}
+```
+
+- Register your device token when your App starts. This ensures that your app no longer receives “cancel” push notifications. Once you have performed this registration, you will only need to register when the device token changes.
+
+Swift
+
+```.swift
+TwilioVoice.register(withAccessToken: accessToken, deviceToken: deviceToken) { (error) in
+    ...
+}
+```
+
+Objective-C
+
+```
+[TwilioVoice registerWithAccessToken:accessToken
+                         deviceToken:self.deviceTokenString
+                          completion:^(NSError *error) {
+    ...
+}
+```
 
 ## Get started with Voice on iOS:
+> NOTE: These sample applications use the Twilio Voice 2.x APIs. If you are using SDK 2.x, we highly recommend planning your migration to 4.0 as soon as possible. Support for 2.x will cease 1/1/2020. Until then, SDK 2.x will only receive fixes for critical or security related issues. For examples using our 4.x APIs, please see the [master](https://github.com/twilio/voice-quickstart-objc/tree/master) branch.
+
 * [Quickstart](#quickstart) - Run the quickstart app
 * [Access Tokens](#access-tokens) - Using access tokens
 * [Managing Audio Interruptions](#managing-audio-interruptions) - Managing audio interruptions


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

- Update Podfile to use Voice iOS 2.1.0
- Update README with migration guide
- Code changes
  - Update device token decoding 
  - Update the mechanism to fulfill the incoming-push completion: now the Voice SDK processes and return a `TVOCallInvite` object synchronously, report the call to CallKit and fulfill the completion before existing the method