### PR TITLE
Make quickstart capable of handling multiple calls or call invites

### DIFF
--- a/ObjcVoiceQuickstart/Base.lproj/Main.storyboard
+++ b/ObjcVoiceQuickstart/Base.lproj/Main.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -23,30 +20,29 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TwilioLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="Yv2-Ab-jqI">
-                                <rect key="frame" x="67" y="115" width="240" height="240"/>
+                                <rect key="frame" x="67.5" y="115" width="240" height="240"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="Ro1-3D-zN6"/>
                                     <constraint firstAttribute="width" secondItem="Yv2-Ab-jqI" secondAttribute="height" multiplier="1:1" id="d66-dM-6YS"/>
                                 </constraints>
                             </imageView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KbF-3Z-6Zb">
-                                <rect key="frame" x="67" y="379" width="240" height="30"/>
+                                <rect key="frame" x="67.5" y="379" width="240" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="2Q5-Ia-8o4"/>
                                 </constraints>
-                                <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V5R-Ky-YRW">
-                                <rect key="frame" x="172" y="465" width="30" height="30"/>
+                                <rect key="frame" x="172.5" y="469" width="30" height="30"/>
                                 <state key="normal" title="Call"/>
                                 <connections>
-                                    <action selector="placeCall:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Zc5-8L-bqN"/>
+                                    <action selector="mainButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2fj-Y6-Nwr"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCr-Ji-S0e">
-                                <rect key="frame" x="67" y="503" width="240" height="88"/>
+                                <rect key="frame" x="67.5" y="507" width="240" height="88"/>
                                 <subviews>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="viR-NY-T2b">
                                         <rect key="frame" x="58" y="8" width="49" height="31"/>
@@ -84,7 +80,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dial a client name or phone number. Leaving the field empty results in an automated response." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r25-bA-TjD">
-                                <rect key="frame" x="59" y="417" width="256" height="40"/>
+                                <rect key="frame" x="59.5" y="421" width="256" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="vAY-mk-e02"/>
                                     <constraint firstAttribute="width" constant="256" id="waL-BM-doB"/>


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### Description
The current sample code assumes that only one call or call invite is is supported at the same time and therefore will not report the VoIP incoming call push notification to CallKit when there is already a pending invite or an active call.

This PR modifies the sample code to be able to handle multiple calls or call invites and ensures that VoIP push notifications are always reported to CallKit as new incoming calls.

### Tested scenarios
This table illustrates how the updated sample app behaves in different call scenarios (all with CallKit integrated):

|     | Scenario | Result |
| --- | -------- | ------ |
| ✅A | Alice calls Bob.<br /> Bob does not accept and let ring.<br />Charlie calls Bob.<br />Bob accepts the call. | Alice and Bob talking.<br />Bob won't see Charlie's incoming call.<br />Charlie was hung up by CallKit when Bob accepted the call. |
| ✅B | Alice calls Bob.<br /> Bob does not accept and let ring.<br />Charlie calls Bob.<br />Bob rejects the call. | Alice was hung up then Charlie's call showed up. |
| ✅C | Alice calls Bob.<br /> Bob accepts the call.<br />Charlie calls Bob.<br />Bob declines Charlie's call. | Charlie was hung up.<br />Alice and Bob continue talking. |
| ✅D | Alice calls Bob.<br /> Bob accepts the call.<br />Charlie calls Bob.<br />Bob "End & Accept" the call. | Alice was hung up.<br />Charlie and Bob talking.<br />*Some audio unit error message observed (see below) |
| ✅E | Bob calls Alice and Alice accepts the call.<br />Charlie calls bob.<br />Bob declines Charlie's call. | Charlie was hung up.<br />Bob and Alice continue talking |
| ✅F | Bob calls Alice and Alice accepts the call.<br />Charlie calls bob.<br />Bob "End & Accept" Charlie's call. | Alice was hung up.<br />Bob and Charlie continue talking |

* In scenario D, some audio uint error messages were observed in the debugging console
```
ObjCVoiceQuickstart[2732:1840483] Incoming call successfully reported.
ObjCVoiceQuickstart[2732:1840483] provider:performEndCallAction:
ObjCVoiceQuickstart[2732:1840638] [aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  44100 Hz, Int16> inf< 1 ch,  44100 Hz, Int16>)
ObjCVoiceQuickstart[2732:1840638] [aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  44100 Hz, Int16> inf< 1 ch,  44100 Hz, Int16>)
ObjCVoiceQuickstart[2732:1840638] [aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  44100 Hz, Int16> inf< 1 ch,  44100 Hz, Int16>)
ObjCVoiceQuickstart[2732:1840638] [aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  44100 Hz, Int16> inf< 1 ch,  44100 Hz, Int16>)
ObjCVoiceQuickstart[2732:1840638] [aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  44100 Hz, Int16> inf< 1 ch,  44100 Hz, Int16>)
ObjCVoiceQuickstart[2732:1840483] provider:didDeactivateAudioSession:
ObjCVoiceQuickstart[2732:1840483] provider:didDeactivateAudioSession:
ObjCVoiceQuickstart[2732:1840483] Call disconnected
ObjCVoiceQuickstart[2732:1840483] provider:didActivateAudioSession:
ObjCVoiceQuickstart[2732:1840483] callDidConnect:
ObjCVoiceQuickstart[2732:1840483] AVAudioSession setAggregatedIOPreference:error: Error Domain=NSOSStatusErrorDomain Code=560030580 "(null)"
```