### PR TITLE
Use Voice iOS 5.1.1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
-github "twilio/twilio-voice-ios" >= 5.1.0
-
+binary "https://raw.githubusercontent.com/twilio/twilio-voice-ios/fix-carthage/twilio-voice-ios.json"

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'ObjCVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 5.1'
+  pod 'TwilioVoice', '~> 5.1.1'
 
   target 'ObjCVoiceQuickstart' do
     platform :ios, '10.0'


### PR DESCRIPTION
Enhancements

- Application name, bundle ID, version, build number, Xcode version and min/major SDK version are now published to Insights. This helps with isolating problems if an issue is encountered.

### Size Impact for 5.1.1

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 6.0 MB | 12.6 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB
